### PR TITLE
Реализация домашнего задания: Координаторы

### DIFF
--- a/Navigation/Coordinators/AppCoordinator.swift
+++ b/Navigation/Coordinators/AppCoordinator.swift
@@ -1,0 +1,48 @@
+import UIKit
+
+final class AppCoordinator: Coordinator {
+    var childCoordinators: [Coordinator] = []
+
+    private let window: UIWindow
+    private let tabBarController = UITabBarController()
+
+    init(window: UIWindow) {
+        self.window = window
+    }
+
+    func start() {
+        let feedNavigationController = UINavigationController()
+        feedNavigationController.tabBarItem = UITabBarItem(
+            title: "Feed",
+            image: UIImage(systemName: "list.bullet"),
+            tag: 0
+        )
+
+        let profileNavigationController = UINavigationController()
+        profileNavigationController.tabBarItem = UITabBarItem(
+            title: "Profile",
+            image: UIImage(systemName: "person.crop.circle"),
+            tag: 1
+        )
+
+        let feedCoordinator = FeedCoordinator(
+            navigationController: feedNavigationController
+        )
+        let profileCoordinator = ProfileCoordinator(
+            navigationController: profileNavigationController
+        )
+
+        childCoordinators = [feedCoordinator, profileCoordinator]
+
+        feedCoordinator.start()
+        profileCoordinator.start()
+
+        tabBarController.viewControllers = [
+            feedNavigationController,
+            profileNavigationController
+        ]
+
+        window.rootViewController = tabBarController
+        window.makeKeyAndVisible()
+    }
+}

--- a/Navigation/Coordinators/Coordinator.swift
+++ b/Navigation/Coordinators/Coordinator.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol Coordinator: AnyObject {
+    var childCoordinators: [Coordinator] { get set }
+    func start()
+}

--- a/Navigation/Coordinators/FeedCoordinator.swift
+++ b/Navigation/Coordinators/FeedCoordinator.swift
@@ -1,0 +1,43 @@
+import UIKit
+import StorageService
+
+final class FeedCoordinator: Coordinator {
+    var childCoordinators: [Coordinator] = []
+
+    let navigationController: UINavigationController
+
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+
+    func start() {
+        let model = FeedModel(secretWord: "swift")
+        let viewModel = FeedViewModel(model: model)
+        let viewController = FeedViewController(viewModel: viewModel)
+        viewController.coordinator = self
+
+        navigationController.setViewControllers([viewController], animated: false)
+    }
+
+    func showPost(_ post: Post) {
+        let viewController = PostViewController(post: post)
+        viewController.coordinator = self
+        navigationController.pushViewController(viewController, animated: true)
+    }
+
+    func showInfo() {
+        let infoViewController = InfoViewController()
+        let modalNavigationController = UINavigationController(
+            rootViewController: infoViewController
+        )
+        modalNavigationController.modalPresentationStyle = .fullScreen
+
+        navigationController.visibleViewController?.present(
+            modalNavigationController,
+            animated: true
+        )
+    }
+}
+
+extension FeedCoordinator: FeedViewControllerCoordinator {}
+extension FeedCoordinator: PostViewControllerCoordinator {}

--- a/Navigation/Coordinators/ProfileCoordinator.swift
+++ b/Navigation/Coordinators/ProfileCoordinator.swift
@@ -1,0 +1,53 @@
+import UIKit
+
+final class ProfileCoordinator: Coordinator {
+    var childCoordinators: [Coordinator] = []
+
+    let navigationController: UINavigationController
+
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+
+    func start() {
+        showLogin()
+    }
+
+    private func showLogin() {
+        let userService: UserService
+
+#if DEBUG
+        userService = TestUserService()
+#else
+        let avatar = UIImage(named: "avatar") ?? UIImage()
+        let currentUser = User(
+            login: "hipster",
+            fullName: "Hipster Cat",
+            avatar: avatar,
+            status: "Waiting for something..."
+        )
+        userService = CurrentUserService(user: currentUser)
+#endif
+
+        let loginFactory: LoginFactory = MyLoginFactory()
+        let viewController = LogInViewController(userService: userService)
+        viewController.loginDelegate = loginFactory.makeLoginInspector()
+        viewController.coordinator = self
+
+        navigationController.setViewControllers([viewController], animated: false)
+    }
+
+    func showProfile(for user: User) {
+        let viewController = ProfileViewController(user: user)
+        viewController.coordinator = self
+        navigationController.pushViewController(viewController, animated: true)
+    }
+
+    func showPhotos() {
+        let viewController = PhotosViewController()
+        navigationController.pushViewController(viewController, animated: true)
+    }
+}
+
+extension ProfileCoordinator: LogInViewControllerCoordinator {}
+extension ProfileCoordinator: ProfileViewControllerCoordinator {}

--- a/Navigation/FeedViewController.swift
+++ b/Navigation/FeedViewController.swift
@@ -1,10 +1,15 @@
 import UIKit
 import StorageService
 
+protocol FeedViewControllerCoordinator: AnyObject {
+    func showPost(_ post: Post)
+}
+
 final class FeedViewController: UIViewController {
 
-    // MARK: - ViewModel
+    // MARK: - Dependencies
     private let viewModel: FeedViewModel
+    weak var coordinator: FeedViewControllerCoordinator?
 
     // MARK: - UI
     private let stackView: UIStackView = {
@@ -132,11 +137,9 @@ final class FeedViewController: UIViewController {
         }
     }
 
-    // MARK: - Navigation
+    // MARK: - Navigation intent
     private func openPost(at index: Int) {
         guard let post = viewModel.post(at: index) else { return }
-
-        let viewController = PostViewController(post: post)
-        navigationController?.pushViewController(viewController, animated: true)
+        coordinator?.showPost(post)
     }
 }

--- a/Navigation/PostViewController.swift
+++ b/Navigation/PostViewController.swift
@@ -1,9 +1,14 @@
 import UIKit
 import StorageService
 
-class PostViewController: UIViewController {
+protocol PostViewControllerCoordinator: AnyObject {
+    func showInfo()
+}
+
+final class PostViewController: UIViewController {
 
     let post: Post
+    weak var coordinator: PostViewControllerCoordinator?
 
     init(post: Post) {
         self.post = post
@@ -19,14 +24,15 @@ class PostViewController: UIViewController {
         title = post.author
         view.backgroundColor = .systemYellow
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Info", style: .plain, target: self, action: #selector(showInfo))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            title: "Info",
+            style: .plain,
+            target: self,
+            action: #selector(showInfo)
+        )
     }
 
-    @objc func showInfo() {
-        let infoVC = InfoViewController()
-        let navVC = UINavigationController(rootViewController: infoVC)
-        navVC.modalPresentationStyle = .fullScreen
-        present(navVC, animated: true)
+    @objc private func showInfo() {
+        coordinator?.showInfo()
     }
 }
- 

--- a/Navigation/Profile/LogInViewController.swift
+++ b/Navigation/Profile/LogInViewController.swift
@@ -1,10 +1,15 @@
 import UIKit
 
+protocol LogInViewControllerCoordinator: AnyObject {
+    func showProfile(for user: User)
+}
+
 class LogInViewController: UIViewController {
 
     // MARK: - Dependencies
     private let userService: UserService
     var loginDelegate: LoginViewControllerDelegate?
+    weak var coordinator: LogInViewControllerCoordinator?
 
     // MARK: - UI Elements
     private let scrollView: UIScrollView = {
@@ -225,9 +230,7 @@ class LogInViewController: UIViewController {
         }
 
         view.endEditing(true)
-
-        let profileViewController = ProfileViewController(user: user)
-        navigationController?.pushViewController(profileViewController, animated: true)
+        coordinator?.showProfile(for: user)
     }
 
     private func showLoginError() {

--- a/Navigation/Profile/ProfileViewController.swift
+++ b/Navigation/Profile/ProfileViewController.swift
@@ -1,9 +1,14 @@
 import UIKit
 
+protocol ProfileViewControllerCoordinator: AnyObject {
+    func showPhotos()
+}
+
 class ProfileViewController: UIViewController {
 
     // MARK: - Properties
     private let user: User
+    weak var coordinator: ProfileViewControllerCoordinator?
 
     private let tableView: UITableView = {
         let tableView = UITableView()
@@ -129,7 +134,7 @@ extension ProfileViewController: UITableViewDelegate {
         tableView.deselectRow(at: indexPath, animated: true)
 
         if indexPath.section == 0 {
-            navigationController?.pushViewController(PhotosViewController(), animated: true)
+            coordinator?.showPhotos()
         }
     }
 }

--- a/Navigation/SceneDelegate.swift
+++ b/Navigation/SceneDelegate.swift
@@ -3,53 +3,17 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    private var appCoordinator: AppCoordinator?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        guard let windowScene = (scene as? UIWindowScene) else { return }
-
-        let tabBarController = UITabBarController()
-
-        let feedModel = FeedModel(secretWord: "swift")
-        let feedViewModel = FeedViewModel(model: feedModel)
-        let feedViewController = FeedViewController(viewModel: feedViewModel)
-        let feedNav = UINavigationController(rootViewController: feedViewController)
-        feedNav.tabBarItem = UITabBarItem(
-            title: "Feed",
-            image: UIImage(systemName: "list.bullet"),
-            tag: 0
-        )
-
-        let userService: UserService
-#if DEBUG
-        userService = TestUserService()
-#else
-        let avatar = UIImage(named: "avatar") ?? UIImage()
-        let currentUser = User(
-            login: "hipster",
-            fullName: "Hipster Cat",
-            avatar: avatar,
-            status: "Waiting for something..."
-        )
-        userService = CurrentUserService(user: currentUser)
-#endif
-
-        let loginFactory: LoginFactory = MyLoginFactory()
-        let logInViewController = LogInViewController(userService: userService)
-        logInViewController.loginDelegate = loginFactory.makeLoginInspector()
-
-        let profileNav = UINavigationController(rootViewController: logInViewController)
-        profileNav.tabBarItem = UITabBarItem(
-            title: "Profile",
-            image: UIImage(systemName: "person.crop.circle"),
-            tag: 1
-        )
-
-        tabBarController.viewControllers = [feedNav, profileNav]
+        guard let windowScene = scene as? UIWindowScene else { return }
 
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = tabBarController
         self.window = window
-        window.makeKeyAndVisible()
+
+        let coordinator = AppCoordinator(window: window)
+        appCoordinator = coordinator
+        coordinator.start()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
## Выполнено

- Добавлен базовый протокол `Coordinator`.
- Добавлен корневой `AppCoordinator`, который управляет `UITabBarController` и удерживает дочерние координаторы.
- Добавлены дочерние `FeedCoordinator` и `ProfileCoordinator`.
- `SceneDelegate` теперь только создаёт окно, удерживает `AppCoordinator` и запускает `start()`.
- `FeedViewController` больше не создаёт `PostViewController` и не выполняет `pushViewController` самостоятельно: он передаёт намерение `showPost(_:)` координатору.
- `PostViewController` передаёт открытие `InfoViewController` координатору; `FeedCoordinator` управляет полной цепочкой `Feed → Post → Info`.
- `LogInViewController` больше не создаёт `ProfileViewController`: после успешной авторизации передаёт `User` в `ProfileCoordinator`.
- `ProfileViewController` больше не создаёт `PhotosViewController`: переход `Profile → Photos` выполняет `ProfileCoordinator`.
- Контроллеры держат координаторы через `weak` routing-протоколы, поэтому навигационная логика вынесена из ViewController без retain cycle.

## Учтён комментарий преподавателя

Координаторы не являются декоративными объектами, которые только вызывают `start()`. После запуска они продолжают функционально координировать реальные пользовательские переходы:

`AppCoordinator`
- `FeedCoordinator`: `Feed → Post → Info`
- `ProfileCoordinator`: `Login → Profile → Photos`

Таким образом создание, push и modal presentation следующих экранов находятся в координаторах, а контроллеры только сообщают о пользовательском намерении перейти.

## Сохранено из предыдущих заданий

- Feed остаётся MVVM-модулем (`FeedViewController → FeedViewModel → FeedModel`).
- Авторизация по-прежнему использует `LoginInspector`, `Checker`, factory и `UserService`.
- Debug credentials: `test / 12345`.
- Release credentials: `hipster / 12345`.

## Git

- Ветка содержит один итоговый коммит поверх принятого MVVM-задания.
- В PR только координаторы и перенос существующей навигации в них.